### PR TITLE
Add: Linked the HPP token address to the Arbitrum Bridge on Sepolia.

### DIFF
--- a/src/app/bridge/BridgeClient.tsx
+++ b/src/app/bridge/BridgeClient.tsx
@@ -15,6 +15,12 @@ export default function BridgeClient() {
   const [openFaqs, setOpenFaqs] = useState<number[]>([]);
   const faqData = bridgeData.faq;
 
+  const currentEnv = (process.env.NEXT_PUBLIC_ENV || 'development').toLowerCase();
+  const isProduction = currentEnv === 'production';
+  const arbitrumBridgeHref = isProduction
+    ? 'https://bridge.arbitrum.io/?destinationChain=190415&sourceChain=ethereum&token=0xe33fbe7584eb79e2673abe576b7ac8c0de62565c'
+    : 'https://portal.arbitrum.io/bridge?destinationChain=hpp-sepolia&sanitized=true&sourceChain=sepolia&tab=bridge&token=0xb34e0d1fee60e078d611d4218afb004b639c7b76';
+
   const openFaq = (id: number) => {
     setOpenFaqs((prev) => (prev.includes(id) ? prev : [...prev, id]));
   };
@@ -70,13 +76,7 @@ export default function BridgeClient() {
                   </p>
                 </div>
                 <div className="pt-6">
-                  <Button
-                    variant="white"
-                    size="lg"
-                    href="https://bridge.arbitrum.io/?destinationChain=190415&sourceChain=ethereum&token=0xe33fbe7584eb79e2673abe576b7ac8c0de62565c"
-                    external
-                    className="cursor-pointer"
-                  >
+                  <Button variant="white" size="lg" href={arbitrumBridgeHref} external className="cursor-pointer">
                     Go to Bridge
                   </Button>
                 </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bridge button now uses an environment-based Arbitrum URL (prod vs Sepolia) with the HPP token preselected.
> 
> - **Bridge page (`src/app/bridge/BridgeClient.tsx`)**:
>   - Add environment detection via `process.env.NEXT_PUBLIC_ENV` to derive `isProduction`.
>   - Compute `arbitrumBridgeHref`:
>     - Production: `https://bridge.arbitrum.io/?destinationChain=190415&sourceChain=ethereum&token=0xe33f...`
>     - Non-prod (Sepolia): `https://portal.arbitrum.io/bridge?destinationChain=hpp-sepolia&sourceChain=sepolia&tab=bridge&token=0xb34e...`
>   - Replace hardcoded Arbitrum bridge `href` with `arbitrumBridgeHref` in the "Go to Bridge" button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 034a7f03ed163e949bd32fecc5bbe65cd9fc1fa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->