### PR TITLE
feat(governance): add governance page with Agora proposals

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,23 @@
   --color-primary: #4949b4;
 }
 
+/* Governance — OnGoing Discussions: 1 col mobile, 2 cols tablet, 3 cols ≥1440px (Tailwind arbitrary min-[1440px] was unreliable in some builds) */
+.hpp-governance-discussions-grid {
+  display: grid;
+  gap: 1.25rem; /* gap-5 */
+  grid-template-columns: minmax(0, 1fr);
+}
+@media (min-width: 768px) {
+  .hpp-governance-discussions-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (min-width: 1440px) {
+  .hpp-governance-discussions-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;

--- a/src/app/governance/GovernanceClient.tsx
+++ b/src/app/governance/GovernanceClient.tsx
@@ -1,0 +1,383 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import Image from 'next/image';
+import Sidebar from '@/components/ui/Sidebar';
+import Button from '@/components/ui/Button';
+import Header from '@/components/ui/Header';
+import Footer from '@/components/ui/Footer';
+import { navItems, legalLinks } from '@/config/navigation';
+import { DotLottieReact } from '@lottiefiles/dotlottie-react';
+import { Aergo, Aqt, Booost } from '@/assets/icons';
+import FaqSection from '@/components/ui/Faq';
+import { governanceData } from '@/static/uiData';
+import { useHppChain } from '@/app/staking/hppClient';
+import dayjs from '@/lib/dayjs';
+import type { AgoraProposal } from '@/lib/agora';
+import {
+  excerptFromMarkdownBody,
+  fetchAgoraProposals,
+  firstMarkdownImageUrl,
+  formatProposalStatusLabel,
+  getAgoraApiBase,
+  getAgoraWebBase,
+  makeHipFallbackImageDataUrl,
+  proposalDetailHref,
+  resolveAgoraAssetUrl,
+} from '@/lib/agora';
+
+const DISCUSSIONS_PAGE_SIZE = 6;
+
+function getProposalStatusBadgeClass(status: string): string {
+  switch (status) {
+    case 'active':
+      // Same green tone used across staking/airdrop "on-going" indicators
+      return 'bg-[#5DF23F] text-black';
+    case 'passed':
+      // Keep default governance badge tone
+      return 'bg-[#5651d8] text-white';
+    case 'failed':
+      // Error/failure tone used in form error states
+      return 'bg-[#FF1312] text-white';
+    case 'cancelled':
+      return 'bg-[#9E9E9E] text-black';
+    case 'pending':
+    default:
+      return 'bg-[#5651d8] text-white';
+  }
+}
+
+/** 1-based page numbers with ellipses when there are many pages */
+function getPaginationItems(totalPages: number, currentPageIndex: number): Array<number | 'ellipsis'> {
+  if (totalPages <= 1) return [];
+  if (totalPages <= 9) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  const cur = currentPageIndex + 1;
+  const set = new Set<number>();
+  set.add(1);
+  set.add(totalPages);
+  for (let i = cur - 1; i <= cur + 1; i++) {
+    if (i >= 1 && i <= totalPages) set.add(i);
+  }
+  const sorted = [...set].sort((a, b) => a - b);
+  const out: Array<number | 'ellipsis'> = [];
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i]! - sorted[i - 1]! > 1) out.push('ellipsis');
+    out.push(sorted[i]!);
+  }
+  return out;
+}
+
+const governanceCards = [
+  {
+    title: 'Discourse Forum',
+    description: 'Legacy hybrid infrastructure at the core of HPP, now transitioning into an AI-native foundation.',
+    href: 'https://forum.hpp.io',
+    icon: Aergo,
+  },
+  {
+    title: 'Voting Layer',
+    description: 'RWA and NFT valuation layer enabling AI-driven asset discovery, pricing, and strategy execution.',
+    href: 'https://snapshot.box/#/s:hpp.eth',
+    icon: Aqt,
+  },
+  {
+    title: 'HPP Report',
+    description: 'Personhood verification and Sybil resistance powered by AI-based deepfake detection and biometrics.',
+    href: 'https://www.booost.live',
+    icon: Booost,
+  },
+];
+
+export default function GovernanceClient() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const { id: chainId } = useHppChain();
+  const agoraApiBase = useMemo(() => getAgoraApiBase(chainId), [chainId]);
+  const agoraWebBase = useMemo(() => getAgoraWebBase(chainId), [chainId]);
+
+  const [proposals, setProposals] = useState<AgoraProposal[]>([]);
+  const [discussionsLoading, setDiscussionsLoading] = useState(true);
+  const [discussionsError, setDiscussionsError] = useState<string | null>(null);
+  const [discussionsPage, setDiscussionsPage] = useState(0);
+
+  const loadProposals = useCallback(async () => {
+    setDiscussionsLoading(true);
+    setDiscussionsError(null);
+    try {
+      const list = await fetchAgoraProposals(agoraApiBase);
+      setProposals(list);
+      setDiscussionsPage(0);
+    } catch (e) {
+      setProposals([]);
+      setDiscussionsError(e instanceof Error ? e.message : 'Failed to load proposals');
+    } finally {
+      setDiscussionsLoading(false);
+    }
+  }, [agoraApiBase]);
+
+  useEffect(() => {
+    void loadProposals();
+  }, [loadProposals]);
+
+  const totalDiscussionPages = Math.max(1, Math.ceil(proposals.length / DISCUSSIONS_PAGE_SIZE));
+  const pagedProposals = useMemo(() => {
+    const start = discussionsPage * DISCUSSIONS_PAGE_SIZE;
+    return proposals.slice(start, start + DISCUSSIONS_PAGE_SIZE);
+  }, [proposals, discussionsPage]);
+
+  useEffect(() => {
+    if (discussionsPage > 0 && discussionsPage >= totalDiscussionPages) {
+      setDiscussionsPage(Math.max(0, totalDiscussionPages - 1));
+    }
+  }, [discussionsPage, totalDiscussionPages]);
+
+  const discussionPaginationItems = useMemo(
+    () => getPaginationItems(totalDiscussionPages, discussionsPage),
+    [totalDiscussionPages, discussionsPage],
+  );
+
+  return (
+    <div className="flex flex-col h-screen bg-black text-white overflow-x-hidden">
+      <Header
+        onMenuClick={() => setSidebarOpen(true)}
+        isSidebarOpen={sidebarOpen}
+        onBackClick={() => setSidebarOpen(false)}
+      />
+
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar
+          navItems={navItems}
+          legalLinks={legalLinks}
+          isOpen={sidebarOpen}
+          onClose={() => setSidebarOpen(false)}
+        />
+
+        <main
+          className={`flex-1 overflow-y-auto transition-all duration-300 ${
+            sidebarOpen ? 'opacity-50 min-[1200px]:opacity-100' : ''
+          }`}
+        >
+          {/* Hero Section (same style as non-home pages) */}
+          <div className="py-12.5">
+            <div className="px-5 max-w-6xl mx-auto">
+              <div className="w-full flex justify-center">
+                <DotLottieReact
+                  src="/lotties/Ecosystem.lottie"
+                  autoplay
+                  loop
+                  className="w-[80px] h-[80px]"
+                  renderConfig={{
+                    autoResize: true,
+                    devicePixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio : 2,
+                    freezeOnOffscreen: true,
+                  }}
+                  layout={{ fit: 'contain', align: [0.5, 0.5] }}
+                />
+              </div>
+              <h1 className="text-[50px] leading-[1.5] font-[900] text-white text-center">HPP Governance</h1>
+              <p className="text-xl text-[#bfbfbf] font-semibold leading-[1.5] max-w-7xl text-center">
+                A place where community and decentralization come together to build the future.
+              </p>
+              <div className="mt-5 flex flex-wrap justify-center gap-3">
+                <Button variant="white" size="md" href="https://forum.hpp.io" external className="cursor-pointer">
+                  💬 Visit Forum
+                </Button>
+                <Button
+                  variant="white"
+                  size="md"
+                  href="https://snapshot.box/#/s:hpp.eth"
+                  external
+                  className="cursor-pointer"
+                >
+                  🗳️ Go to Vote
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <div className="px-5 max-w-6xl mx-auto mt-20">
+            <h2 className="text-3xl leading-[1.5] font-[900] text-white mb-5">Core Governance Access</h2>
+            <div className="grid grid-cols-1 min-[810px]:grid-cols-3 gap-5 justify-items-center">
+              {governanceCards.map((item) => (
+                <a
+                  key={item.title}
+                  href={item.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="relative block rounded-[5px] p-6 pb-10 border border-transparent bg-primary w-full lg:max-w-[400px] transition-transform duration-200 hover:opacity-95"
+                >
+                  <div className="mb-3 flex items-center">
+                    <div className="w-12.5 h-12.5 bg-white rounded-[5px] flex items-center justify-center">
+                      <Image src={item.icon} alt={item.title} width={28} height={28} />
+                    </div>
+                  </div>
+                  <h3 className="text-xl leading-[24px] tracking-[0] font-semibold text-white mb-2.5">{item.title}</h3>
+                  <p className="text-base text-[#FFED2B] leading-[1.5] font-normal tracking-[0.8px]">
+                    {item.description}
+                  </p>
+                  <div className="absolute bottom-5 right-5">
+                    <svg className="w-[22px] h-[22px] text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5-5 5M6 12h12" />
+                    </svg>
+                  </div>
+                </a>
+              ))}
+            </div>
+          </div>
+
+          {/* OnGoing Discussions — HPP Agora GET /proposals */}
+          <div className="px-5 max-w-6xl mx-auto mt-20">
+            <h2 className="text-3xl leading-[1.5] font-[900] text-white mb-5">OnGoing Discussions</h2>
+
+            {discussionsLoading && (
+              <div className="flex min-h-[200px] flex-col items-center justify-center gap-4 rounded-[5px] bg-[#111111] py-16">
+                <DotLottieReact
+                  src="/lotties/Loading.lottie"
+                  autoplay
+                  loop
+                  className="h-[48px] w-[48px]"
+                  renderConfig={{
+                    autoResize: true,
+                    devicePixelRatio: typeof window !== 'undefined' ? window.devicePixelRatio : 2,
+                    freezeOnOffscreen: true,
+                  }}
+                  layout={{ fit: 'contain', align: [0.5, 0.5] }}
+                />
+              </div>
+            )}
+
+            {!discussionsLoading && discussionsError && (
+              <div className="rounded-[5px] bg-[#111111] px-5 py-10 text-center">
+                <p className="text-base text-[#bfbfbf] mb-4">{discussionsError}</p>
+                <p className="text-sm text-[#888] mb-6 max-w-xl mx-auto">
+                  If this is a local build, the Agora API must allow your origin in CORS (see Workers API docs). You can
+                  set <code className="text-white">NEXT_PUBLIC_HPP_AGORA_API_URL</code> to point to the correct
+                  environment.
+                </p>
+                <Button variant="white" size="md" onClick={() => void loadProposals()} className="cursor-pointer">
+                  Retry
+                </Button>
+              </div>
+            )}
+
+            {!discussionsLoading && !discussionsError && proposals.length === 0 && (
+              <div className="rounded-[5px] bg-[#111111] px-5 py-16 text-center text-[#bfbfbf]">
+                No proposals yet. Check back soon or open Agora to create one.
+              </div>
+            )}
+
+            {!discussionsLoading && !discussionsError && proposals.length > 0 && (
+              <>
+                <div className="hpp-governance-discussions-grid">
+                  {pagedProposals.map((post) => {
+                    const imgRef = firstMarkdownImageUrl(post.body);
+                    const imageSrc = imgRef
+                      ? resolveAgoraAssetUrl(agoraApiBase, imgRef)
+                      : makeHipFallbackImageDataUrl(post.id);
+                    const href = proposalDetailHref(agoraWebBase, post.id);
+                    const dateLabel = dayjs.unix(post.createdAt).format('MMM D, YYYY');
+                    const isoDate = dayjs.unix(post.createdAt).toISOString();
+                    const excerpt = excerptFromMarkdownBody(post.body);
+                    const statusLabel = formatProposalStatusLabel(post.status);
+                    const statusBadgeClass = getProposalStatusBadgeClass(post.status);
+
+                    return (
+                      <a
+                        key={post.id}
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group relative grid h-full w-full grid-rows-[minmax(0,1fr)_minmax(0,1fr)] overflow-hidden rounded-[5px] bg-[#111111] transition-opacity duration-200 hover:opacity-95 aspect-[10/11] md:aspect-auto md:min-h-[300px]"
+                      >
+                        <div className="relative min-h-0 min-w-0 bg-[#1a1a1a]">
+                          <Image
+                            src={imageSrc}
+                            alt={post.title}
+                            fill
+                            className="object-cover"
+                            sizes="(max-width: 767px) 100vw, (max-width: 1439px) 50vw, 33vw"
+                          />
+                        </div>
+                        <div className="relative flex min-h-0 flex-col overflow-hidden p-5 pb-12">
+                          <div className="mb-3 flex flex-wrap items-center gap-2">
+                            <time className="text-sm font-normal leading-[1.5] text-[#bfbfbf]" dateTime={isoDate}>
+                              {dateLabel}
+                            </time>
+                            <span
+                              className={`rounded-full px-2.5 py-1 text-xs font-semibold leading-none ${statusBadgeClass}`}
+                            >
+                              {statusLabel}
+                            </span>
+                          </div>
+                          <h3 className="text-xl font-bold leading-[1.35] text-white line-clamp-2">{post.title}</h3>
+                          <p className="mt-2 text-base font-normal leading-[1.5] text-[#bfbfbf] line-clamp-3">
+                            {excerpt}
+                          </p>
+                          <div className="absolute bottom-5 right-5">
+                            <svg
+                              className="h-[22px] w-[22px] text-white transition-transform duration-200 group-hover:translate-x-0.5"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                              aria-hidden
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M13 7l5 5-5 5M6 12h12"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </a>
+                    );
+                  })}
+                </div>
+
+                {discussionPaginationItems.length > 0 && (
+                  <nav className="mt-10 flex flex-wrap items-center justify-center gap-2" aria-label="Proposals pages">
+                    {discussionPaginationItems.map((item, idx) =>
+                      item === 'ellipsis' ? (
+                        <span
+                          key={`ellipsis-${idx}`}
+                          className="flex h-10 min-w-10 items-center justify-center px-1 text-sm font-medium text-[#666]"
+                          aria-hidden
+                        >
+                          …
+                        </span>
+                      ) : (
+                        <button
+                          key={item}
+                          type="button"
+                          aria-label={`Page ${item}`}
+                          aria-current={item === discussionsPage + 1 ? 'page' : undefined}
+                          onClick={() => setDiscussionsPage(item - 1)}
+                          className={[
+                            'flex h-10 min-w-10 cursor-pointer items-center justify-center rounded-[5px] px-3 text-sm font-semibold tabular-nums transition-colors ring-1 ring-inset',
+                            item === discussionsPage + 1
+                              ? 'bg-primary text-white ring-transparent'
+                              : 'bg-[#111111] text-[#bfbfbf] ring-white/[0.08] hover:bg-white/[0.06] hover:text-white',
+                          ].join(' ')}
+                        >
+                          {item}
+                        </button>
+                      ),
+                    )}
+                  </nav>
+                )}
+              </>
+            )}
+          </div>
+
+          <div className="px-5 max-w-6xl mx-auto mt-20 mb-25 w-full">
+            <FaqSection title="Frequently Asked Questions" items={governanceData.faq} />
+          </div>
+
+          <Footer />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import type { Metadata } from 'next';
+import GovernanceClient from './GovernanceClient';
+
+export const metadata: Metadata = {
+  title: 'Governance | HPP Portal',
+  description: 'Join HPP governance through community forum, voting, and governance participation channels.',
+};
+
+export default function Governance() {
+  return <GovernanceClient />;
+}

--- a/src/config/navigation.tsx
+++ b/src/config/navigation.tsx
@@ -37,8 +37,7 @@ export const navItems = [
   },
   {
     label: 'Governance',
-    href: 'https://snapshot.box/#/s:hpp.eth',
-    external: true,
+    href: '/governance',
     icon: <GovernanceIcon />,
   },
   {

--- a/src/lib/agora.ts
+++ b/src/lib/agora.ts
@@ -1,0 +1,138 @@
+/**
+ * HPP Agora Workers API — proposal list for Governance UI.
+ * @see Workers API (GET /proposals)
+ */
+
+export interface AgoraProposal {
+  id: number;
+  contentHash: string;
+  title: string;
+  body: string;
+  author: string;
+  startTime: number;
+  endTime: number;
+  snapshotBlock: number;
+  quorum: string;
+  forVotes: string;
+  againstVotes: string;
+  abstainVotes: string;
+  status: 'pending' | 'active' | 'passed' | 'failed' | 'cancelled';
+  cancelled: boolean;
+  hidden?: boolean;
+  voteCount?: number;
+  createdAt: number;
+}
+
+export interface AgoraProposalsResponse {
+  proposals: AgoraProposal[];
+}
+
+export function getAgoraApiBase(chainId: number): string {
+  const fromEnv = typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_HPP_AGORA_API_URL : undefined;
+  if (fromEnv?.trim()) return fromEnv.replace(/\/$/, '');
+  return chainId === 190415 ? 'https://agora-api.hpp.io' : 'https://agora-sepolia-api.hpp.io';
+}
+
+/** Public Agora web app — proposal detail links */
+export function getAgoraWebBase(chainId: number): string {
+  const fromEnv = typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_HPP_AGORA_WEB_URL : undefined;
+  if (fromEnv?.trim()) return fromEnv.replace(/\/$/, '');
+  return chainId === 190415 ? 'https://agora.hpp.io' : 'https://agora-sepolia.hpp.io';
+}
+
+export function proposalDetailHref(webBase: string, proposalId: number): string {
+  const base = webBase.replace(/\/$/, '');
+  return `${base}/proposal/${proposalId}`;
+}
+
+export async function fetchAgoraProposals(apiBase: string, init?: RequestInit): Promise<AgoraProposal[]> {
+  const url = `${apiBase.replace(/\/$/, '')}/proposals`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      accept: 'application/json',
+      ...(init?.headers as Record<string, string>),
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Agora proposals failed (${res.status}): ${text.slice(0, 200)}`);
+  }
+  const data = (await res.json()) as AgoraProposalsResponse;
+  return Array.isArray(data.proposals) ? data.proposals : [];
+}
+
+/** Resolve relative upload paths against API origin */
+export function resolveAgoraAssetUrl(apiBase: string, urlOrPath: string): string {
+  const t = urlOrPath.trim();
+  if (!t) return '';
+  if (/^https?:\/\//i.test(t)) return t;
+  try {
+    return new URL(t.startsWith('/') ? t : `/${t}`, apiBase.replace(/\/$/, '/') + '/').href;
+  } catch {
+    return t;
+  }
+}
+
+const IMG_IN_MD = /!\[[^\]]*\]\(([^)\s]+)\)/;
+
+export function firstMarkdownImageUrl(body: string): string | null {
+  const m = body.match(IMG_IN_MD);
+  return m?.[1]?.trim() ?? null;
+}
+
+export function excerptFromMarkdownBody(body: string, maxLen = 180): string {
+  let t = body
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(IMG_IN_MD, ' ')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/[*_`>|]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (t.length > maxLen) t = t.slice(0, maxLen).replace(/\s+\S*$/, '') + '…';
+  return t || '—';
+}
+
+export function formatProposalStatusLabel(status: string): string {
+  const map: Record<string, string> = {
+    pending: 'Pending',
+    active: 'Active',
+    passed: 'Passed',
+    failed: 'Failed',
+    cancelled: 'Cancelled',
+  };
+  return map[status] ?? status.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Build an on-the-fly default cover image for proposals with no image.
+ * Uses a data URL SVG so no backend/image asset is required.
+ */
+export function makeHipFallbackImageDataUrl(proposalId: number): string {
+  const label = `HIP-${proposalId}`;
+  const svg = `
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="450" viewBox="0 0 800 450">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#121212"/>
+      <stop offset="100%" stop-color="#1A1A1A"/>
+    </linearGradient>
+    <radialGradient id="accent" cx="0.2" cy="0.1" r="1">
+      <stop offset="0%" stop-color="#5651d8" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#5651d8" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="800" height="450" fill="url(#bg)"/>
+  <rect width="800" height="450" fill="url(#accent)"/>
+  <rect x="36" y="36" rx="10" ry="10" width="728" height="378" fill="none" stroke="#2a2a2a" stroke-width="2"/>
+  <text x="400" y="218" text-anchor="middle" fill="#ffffff"
+    font-family="'Pretendard Variable','Pretendard',system-ui,-apple-system,'Segoe UI',sans-serif"
+    font-size="72" font-weight="800" letter-spacing="1">${label}</text>
+  <text x="400" y="268" text-anchor="middle" fill="#bfbfbf"
+    font-family="'Pretendard Variable','Pretendard',system-ui,-apple-system,'Segoe UI',sans-serif"
+    font-size="24" font-weight="500">HPP Improvement Proposal</text>
+</svg>`.trim();
+
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}

--- a/src/static/uiData.tsx
+++ b/src/static/uiData.tsx
@@ -191,6 +191,42 @@ export const ecosystemData = {
   ],
 };
 
+// Governance Page Data
+export const governanceData = {
+  faq: [
+    {
+      id: 1,
+      question: 'What is HPP Governance?',
+      answer:
+        'HPP Governance is the process where the community creates proposals, discusses changes, and votes on key decisions for the HPP ecosystem. In this portal, governance activity is provided through Agora so users can follow the full proposal lifecycle in one place.',
+    },
+    {
+      id: 2,
+      question: 'Can I create proposals and vote directly in Agora?',
+      answer:
+        'Yes. Connect your wallet in Agora, create or open a proposal, and submit your vote from the same interface. Proposal eligibility, quorum, and voting period are defined by governance rules and shown in each proposal detail.',
+    },
+    {
+      id: 3,
+      question: 'Can I manage proposal drafts in Agora?',
+      answer:
+        'Yes. Agora supports draft workflows so you can save, edit, and refine proposal content before publishing. This helps teams align on scope and wording before opening a formal vote.',
+    },
+    {
+      id: 4,
+      question: 'Where can I check proposal status and vote results?',
+      answer:
+        'Agora shows proposal status (pending, active, passed, failed, cancelled), vote counts, and details for each proposal. You can track progress in real time from the OnGoing Discussions list and each proposal page.',
+    },
+    {
+      id: 5,
+      question: 'How do I stay updated on new governance activity?',
+      answer:
+        'Use Agora as your primary governance dashboard for new proposals, status changes, and voting updates. You can also follow official HPP announcement channels for major governance notices.',
+    },
+  ],
+};
+
 // Bridge Page Data
 export const bridgeData = {
   faq: [


### PR DESCRIPTION
- Point sidebar Governance to /governance instead of external Snapshot
- Add GovernanceClient: hero, core access cards, OnGoing Discussions from
  Agora GET /proposals with numbered pagination and responsive grid CSS
- Add src/lib/agora.ts for API base URLs, proposal links, excerpt/image
  helpers, and HIP-{id} SVG fallback covers
- Add governance FAQ copy centered on Agora