### PR TITLE
fix(ui): improve governance empty states and disable auto token-add prompts

### DIFF
--- a/src/app/airdrop/[id]/AirdropDetailClient.tsx
+++ b/src/app/airdrop/[id]/AirdropDetailClient.tsx
@@ -26,7 +26,7 @@ import { hppVestingABI } from '../abi';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setAirdropDetailLoading, setAirdropDetail, type AirdropDetailData } from '@/store/slices';
 import { useToast } from '@/hooks/useToast';
-import { useAutoWatchAssetOnce, useEnsureChain } from '@/hooks/useWallet';
+import { useEnsureChain } from '@/hooks/useWallet';
 import { config as wagmiConfig } from '@/config/walletConfig';
 
 export default function AirdropDetailClient({ id }: { id: string }) {
@@ -39,7 +39,6 @@ export default function AirdropDetailClient({ id }: { id: string }) {
   const { disconnect } = useDisconnect();
   const { showToast, hideToast } = useToast();
   const ensureChain = useEnsureChain();
-  const autoWatchAssetOnce = useAutoWatchAssetOnce();
   const [error, setError] = useState<string | null>(null);
   const [historyPage, setHistoryPage] = useState(1);
   const [vestingSchedule, setVestingSchedule] = useState<[`0x${string}`, bigint, bigint, boolean] | null>(null);
@@ -92,13 +91,7 @@ export default function AirdropDetailClient({ id }: { id: string }) {
       rpcUrls: [rpcUrl],
       nativeCurrency: hppChain.nativeCurrency,
     });
-    if (HPP_TOKEN_ADDRESS) {
-      await autoWatchAssetOnce({
-        chainId: HPP_CHAIN_ID,
-        token: { address: HPP_TOKEN_ADDRESS, symbol: 'HPP', decimals: 18 },
-      });
-    }
-  }, [ensureChain, HPP_CHAIN_ID, hppChain.name, hppChain.nativeCurrency, rpcUrl, HPP_TOKEN_ADDRESS, autoWatchAssetOnce]);
+  }, [ensureChain, HPP_CHAIN_ID, hppChain.name, hppChain.nativeCurrency, rpcUrl]);
 
   // Contract address: use API/Redux data (do not override with env).
   const contractAddress = useMemo(() => {

--- a/src/app/governance/GovernanceClient.tsx
+++ b/src/app/governance/GovernanceClient.tsx
@@ -65,13 +65,6 @@ function getFilterButtonClass(filterId: GovernanceFilter, active: boolean): stri
   return 'bg-primary text-white';
 }
 
-function getEmptyStateMessage(filterId: GovernanceFilter): string {
-  if (filterId === 'proposal') return 'No proposals yet';
-  if (filterId === 'discussion') return 'No discussions yet';
-  if (filterId === 'update') return 'Updates coming soon';
-  return 'No governance posts yet';
-}
-
 function discussionKindFromTitle(title: string): GovernanceFeedKind {
   const s = title.toLowerCase();
   if (s.includes('update')) return 'update';
@@ -358,7 +351,9 @@ export default function GovernanceClient() {
 
             {!discussionsLoading && !discussionsError && filteredItems.length === 0 && (
               <div className="rounded-[5px] bg-[#111111] px-5 py-16 text-center text-[#bfbfbf]">
-                {getEmptyStateMessage(activeFilter)}
+                {activeFilter === 'all'
+                  ? 'Governance posts coming soon'
+                  : `${activeFilter.charAt(0).toUpperCase()}${activeFilter.slice(1)}s coming soon`}
               </div>
             )}
 

--- a/src/app/staking/StakingClient.tsx
+++ b/src/app/staking/StakingClient.tsx
@@ -19,7 +19,7 @@ import { standardArbErc20Abi, hppStakingAbi } from './abi';
 import { formatDisplayAmount, PERCENTS, computePercentAmount, formatTokenBalance } from '@/lib/helpers';
 import { useHppPublicClient, useHppChain } from './hppClient';
 import { useToast } from '@/hooks/useToast';
-import { useAutoWatchAssetOnce, useEnsureChain } from '@/hooks/useWallet';
+import { useEnsureChain } from '@/hooks/useWallet';
 import { config as wagmiConfig } from '@/config/walletConfig';
 import axios from 'axios';
 import OverviewSection from './OverviewSection';
@@ -284,7 +284,6 @@ export default function StakingClient() {
   const publicClient = useHppPublicClient();
   const { showToast } = useToast();
   const ensureChain = useEnsureChain();
-  const autoWatchAssetOnce = useAutoWatchAssetOnce();
   const { data: walletClient } = useWalletClient();
   const currentChainId = useChainId();
   const { chain: hppChain, id: HPP_CHAIN_ID, rpcUrl } = useHppChain();
@@ -713,12 +712,6 @@ export default function StakingClient() {
       rpcUrls: [rpcUrl],
       nativeCurrency: hppChain.nativeCurrency,
     });
-    if (HPP_TOKEN_ADDRESS) {
-      await autoWatchAssetOnce({
-        chainId: HPP_CHAIN_ID,
-        token: { address: HPP_TOKEN_ADDRESS, symbol: 'HPP', decimals: 18 },
-      });
-    }
   };
 
   // Balance refresh helper

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -14,13 +14,6 @@ export interface EnsureChainOptions {
   nativeCurrency?: NativeCurrency;
 }
 
-export interface WatchAssetErc20Options {
-  address: `0x${string}`;
-  symbol: string;
-  decimals: number;
-  image?: string;
-}
-
 /**
  * Hook that ensures the connected wallet is on the specified chain.
  * - Prefers wagmi's switchChain (works with WalletConnect/AppKit mobile).
@@ -97,89 +90,6 @@ export function useEnsureChain() {
 
       // If all attempts failed, rethrow the original error
       throw err;
-    }
-  };
-}
-
-/**
- * Hook that requests adding an ERC-20 token to the connected wallet UI.
- * Uses wallet transport first (WalletConnect/AppKit friendly), then injected provider fallback.
- */
-export function useWatchAsset() {
-  const { data: walletClient } = useWalletClient();
-
-  return async (token: WatchAssetErc20Options): Promise<boolean> => {
-    const params = {
-      type: 'ERC20',
-      options: {
-        address: token.address,
-        symbol: token.symbol,
-        decimals: token.decimals,
-        ...(token.image ? { image: token.image } : {}),
-      },
-    };
-
-    const transportRequest = (walletClient as any)?.transport?.request as
-      | ((args: { method: string; params?: any[] | Record<string, any> }) => Promise<any>)
-      | undefined;
-    if (transportRequest) {
-      try {
-        const res = await transportRequest({ method: 'wallet_watchAsset', params });
-        return !!res;
-      } catch {
-        // fall through to injected fallback
-      }
-    }
-
-    const injected = typeof window !== 'undefined' ? (window as any).ethereum : undefined;
-    const injectedRequest: undefined | ((args: { method: string; params?: any }) => Promise<any>) =
-      injected?.request?.bind(injected);
-    if (injectedRequest) {
-      const res = await injectedRequest({ method: 'wallet_watchAsset', params });
-      return !!res;
-    }
-
-    return false;
-  };
-}
-
-/**
- * Best-effort, "prompt once" token add UX helper.
- * - Skips if already prompted recently.
- * - Marks as prompted on success OR user rejection to avoid nagging.
- */
-export function useAutoWatchAssetOnce() {
-  const watchAsset = useWatchAsset();
-
-  return async (args: { chainId: number; token: WatchAssetErc20Options; keyPrefix?: string; force?: boolean }) => {
-    if (typeof window === 'undefined') return false;
-    const keyPrefix = args.keyPrefix || 'hpp:watchAsset';
-    const tokenKey = `${keyPrefix}:${args.chainId}:${String(args.token.address).toLowerCase()}`;
-
-    if (!args.force) {
-      try {
-        const last = window.localStorage.getItem(tokenKey);
-        if (last) return false;
-      } catch {
-        // ignore storage errors (private mode, etc.)
-      }
-    }
-
-    try {
-      const added = await watchAsset(args.token);
-      try {
-        window.localStorage.setItem(tokenKey, String(Date.now()));
-      } catch {}
-      return added;
-    } catch (e: any) {
-      // If user rejected the request, avoid prompting again automatically.
-      const code = e?.code;
-      if (code === 4001) {
-        try {
-          window.localStorage.setItem(tokenKey, String(Date.now()));
-        } catch {}
-      }
-      return false;
     }
   };
 }


### PR DESCRIPTION
## Summary
- Updated Governance empty-state messaging to use a consistent “coming soon” tone per active filter.
- Simplified empty-state rendering by inlining filter-based copy logic in `GovernanceClient`.
- Removed automatic `wallet_watchAsset` prompt flow from staking and airdrop interactions.
- Deleted unused watch-asset helper hooks/types from `useWallet`.
- Restored sidebar order so `HPP Hub` appears below `Build`.

## Why
- Prevent repeated MetaMask token-add popups during normal user flows.
- Keep empty-state UX clearer while backend/update feeds are still being finalized.
- Reduce unnecessary helper complexity and dead code.

## Test Plan
- [ ] Open Governance and verify empty-state text for `ALL`, `Proposal`, `Discussion`, and `Update`.
- [ ] Confirm no automatic MetaMask “Add token” popup appears in staking actions.
- [ ] Confirm no automatic MetaMask “Add token” popup appears in airdrop detail actions.
- [ ] Verify sidebar navigation order is `Governance -> Build -> HPP Hub`.
- [ ] Run lint/build checks.